### PR TITLE
adding new Is* methods that can be used to check log level to ensure log args aren't evaluated in certain conditions

### DIFF
--- a/consolelog.go
+++ b/consolelog.go
@@ -110,3 +110,31 @@ func (l *ConsoleLogger) Print(lvl int, v ...interface{}) {
 func (l *ConsoleLogger) Printf(lvl int, format string, v ...interface{}) {
 	l.output(&Message{lvl, fmt.Sprintf(format, v...), time.Now()})
 }
+
+func (l *ConsoleLogger) GetLevel() int {
+	return l.outLevel
+}
+
+func (l *ConsoleLogger) IsFatal() bool {
+	return l.outLevel <= FATAL
+}
+
+func (l *ConsoleLogger) IsError() bool {
+	return l.outLevel <= ERROR
+}
+
+func (l *ConsoleLogger) IsWarn() bool {
+	return l.outLevel <= WARN
+}
+
+func (l *ConsoleLogger) IsInfo() bool {
+	return l.outLevel <= INFO
+}
+
+func (l *ConsoleLogger) IsDebug() bool {
+	return l.outLevel <= DEBUG
+}
+
+func (l *ConsoleLogger) IsTrace() bool {
+	return l.outLevel <= TRACE
+}

--- a/filelog.go
+++ b/filelog.go
@@ -332,3 +332,31 @@ func (l *FileLogger) Print(lvl int, v ...interface{}) {
 func (l *FileLogger) Printf(lvl int, format string, v ...interface{}) {
 	l.output(&Message{lvl, fmt.Sprintf(format, v...), time.Now()})
 }
+
+func (l *FileLogger) GetLevel() int {
+	return l.outLevel
+}
+
+func (l *FileLogger) IsFatal() bool {
+	return l.outLevel <= FATAL
+}
+
+func (l *FileLogger) IsError() bool {
+	return l.outLevel <= ERROR
+}
+
+func (l *FileLogger) IsWarn() bool {
+	return l.outLevel <= WARN
+}
+
+func (l *FileLogger) IsInfo() bool {
+	return l.outLevel <= INFO
+}
+
+func (l *FileLogger) IsDebug() bool {
+	return l.outLevel <= DEBUG
+}
+
+func (l *FileLogger) IsTrace() bool {
+	return l.outLevel <= TRACE
+}

--- a/lumber.go
+++ b/lumber.go
@@ -33,6 +33,15 @@ type Logger interface {
 	Info(string, ...interface{})
 	Debug(string, ...interface{})
 	Trace(string, ...interface{})
+
+	IsFatal() bool
+	IsError() bool
+	IsWarn() bool
+	IsInfo() bool
+	IsDebug() bool
+	IsTrace() bool
+	GetLevel() int
+
 	Print(int, ...interface{})
 	Printf(int, string, ...interface{})
 	Level(int)
@@ -107,4 +116,32 @@ func Print(lvl int, v ...interface{}) {
 
 func Printf(lvl int, format string, v ...interface{}) {
 	stdLog.output(&Message{lvl, fmt.Sprintf(format, v...), time.Now()})
+}
+
+func GetLevel() int {
+	return stdLog.GetLevel()
+}
+
+func IsFatal() bool {
+	return stdLog.IsFatal()
+}
+
+func IsError() bool {
+	return stdLog.IsError()
+}
+
+func IsWarn() bool {
+	return stdLog.IsWarn()
+}
+
+func IsInfo() bool {
+	return stdLog.IsInfo()
+}
+
+func IsDebug() bool {
+	return stdLog.IsDebug()
+}
+
+func IsTrace() bool {
+	return stdLog.IsTrace()
 }

--- a/lumber_test.go
+++ b/lumber_test.go
@@ -1,0 +1,152 @@
+package lumber
+
+import (
+	"testing"
+)
+
+func TestIsStar(t *testing.T) {
+
+	log := NewConsoleLogger(FATAL)
+	if !log.IsFatal() {
+		t.Fatal("Fatal should be logged")
+	}
+	if log.IsError() {
+		t.Fatal("Error should not be logged")
+	}
+	if log.IsWarn() {
+		t.Fatal("Warn should not be logged")
+	}
+	if log.IsInfo() {
+		t.Fatal("Info should not be logged")
+	}
+	if log.IsDebug() {
+		t.Fatal("Debug should not be logged")
+	}
+	if log.IsTrace() {
+		t.Fatal("Trace should not be logged")
+
+	}
+
+	log.Level(ERROR)
+	if !log.IsFatal() {
+		t.Fatal("Fatal should be logged")
+	}
+	if !log.IsError() {
+		t.Fatal("Error should be logged")
+	}
+	if log.IsWarn() {
+		t.Fatal("Warn should not be logged")
+	}
+	if log.IsInfo() {
+		t.Fatal("Info should not be logged")
+	}
+	if log.IsDebug() {
+		t.Fatal("Debug should not be logged")
+	}
+	if log.IsTrace() {
+		t.Fatal("Trace should not be logged")
+
+	}
+
+	log.Level(WARN)
+	if !log.IsFatal() {
+		t.Fatal("Fatal should be logged")
+	}
+	if !log.IsError() {
+		t.Fatal("Error should be logged")
+	}
+	if !log.IsWarn() {
+		t.Fatal("Warn should be logged")
+	}
+	if log.IsInfo() {
+		t.Fatal("Info should not be logged")
+	}
+	if log.IsDebug() {
+		t.Fatal("Debug should not be logged")
+	}
+	if log.IsTrace() {
+		t.Fatal("Trace should not be logged")
+	}
+
+	log.Level(INFO)
+	if !log.IsFatal() {
+		t.Fatal("Fatal should be logged")
+	}
+	if !log.IsError() {
+		t.Fatal("Error should be logged")
+	}
+	if !log.IsWarn() {
+		t.Fatal("Warn should be logged")
+	}
+	if !log.IsInfo() {
+		t.Fatal("Info should be logged")
+	}
+	if log.IsDebug() {
+		t.Fatal("Debug should not be logged")
+	}
+	if log.IsTrace() {
+		t.Fatal("Trace should not be logged")
+	}
+
+	log.Level(DEBUG)
+	if !log.IsFatal() {
+		t.Fatal("Fatal should be logged")
+	}
+	if !log.IsError() {
+		t.Fatal("Error should be logged")
+	}
+	if !log.IsWarn() {
+		t.Fatal("Warn should be logged")
+	}
+	if !log.IsInfo() {
+		t.Fatal("Info should be logged")
+	}
+	if !log.IsDebug() {
+		t.Fatal("Debug should be logged")
+	}
+	if log.IsTrace() {
+		t.Fatal("Trace should not be logged")
+	}
+
+	log.Level(TRACE)
+	if !log.IsFatal() {
+		t.Fatal("Fatal should be logged")
+	}
+	if !log.IsError() {
+		t.Fatal("Error should be logged")
+	}
+	if !log.IsWarn() {
+		t.Fatal("Warn should be logged")
+	}
+	if !log.IsInfo() {
+		t.Fatal("Info should be logged")
+	}
+	if !log.IsDebug() {
+		t.Fatal("Debug should be logged")
+	}
+	if !log.IsTrace() {
+		t.Fatal("Trace should be logged")
+	}
+}
+
+func TestMultiIS(t *testing.T) {
+	log := NewMultiLogger()
+	log.AddLoggers(NewConsoleLogger(WARN))
+	log.AddLoggers(NewConsoleLogger(INFO))
+
+	if log.IsTrace() {
+		t.Fatal("Logger should return trace")
+	}
+	if !log.IsInfo() {
+		t.Fatal("Logger should return info")
+	}
+	if !log.IsWarn() {
+		t.Fatal("Logger should return warn")
+	}
+	if !log.IsError() {
+		t.Fatal("Logger should return error")
+	}
+	if !log.IsFatal() {
+		t.Fatal("Logger should return fatal")
+	}
+}

--- a/multilog.go
+++ b/multilog.go
@@ -94,3 +94,37 @@ func (p *MultiLogger) Print(lvl int, v ...interface{}) {
 func (p *MultiLogger) Printf(lvl int, format string, v ...interface{}) {
 	p.output(&Message{lvl, fmt.Sprintf(format, v...), time.Now()})
 }
+
+func (p *MultiLogger) GetLevel() int {
+	level := FATAL
+	for _, logger := range p.loggers {
+		if logger.GetLevel() <= level {
+			level = logger.GetLevel()
+		}
+	}
+	return level
+}
+
+func (p *MultiLogger) IsFatal() bool {
+	return p.GetLevel() <= FATAL
+}
+
+func (p *MultiLogger) IsError() bool {
+	return p.GetLevel() <= ERROR
+}
+
+func (p *MultiLogger) IsWarn() bool {
+	return p.GetLevel() <= WARN
+}
+
+func (p *MultiLogger) IsInfo() bool {
+	return p.GetLevel() <= INFO
+}
+
+func (p *MultiLogger) IsDebug() bool {
+	return p.GetLevel() <= DEBUG
+}
+
+func (p *MultiLogger) IsTrace() bool {
+	return p.GetLevel() <= TRACE
+}


### PR DESCRIPTION
This methods will be useful so that more involved logging can be turned on when the code is in a lower debug state

i.e.  
JSON serialized Request and Response objects when in debugging mode, which won't be logged when in production.

if log.IsTrace() {
  b, _ := json.MarshalIdent(struct), "", "  ")
  log.Trace(string(b))
}
